### PR TITLE
Radarr Auto Trailer post process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /downloads
 .DS_Store
+settings.ini

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Simple set of python scripts for downloading a movie trailer from Apple or from 
 
 ## Installation
 ```
-sudo -H pip install -r /path/to/scripts/requirements.txt
+sudo -H pip install -r requirements.txt
 ```
 
 ## Settings
+```
+cp settings.ini.example settings.ini
+```
 Edit the **settings.ini** file. Here you can add your api key for TMDB and set up your country code, language, resolution settings, subfolders, and custom formatting.
 
 ## Usage
@@ -28,19 +31,19 @@ Edit the **settings.ini** file. Here you can add your api key for TMDB and set u
 
 To download a trailer for a specific movie, use the command below. You will need to provide the movie title, year, and directory or file to the script.
 ```
-python3 /path/to/download.py --title "A Star Is Born" --year "2018" --directory "/path/to/movies/A Star Is Born (2018)"
+python3 download.py --title "A Star Is Born" --year "2018" --directory "/path/to/movies/A Star Is Born (2018)"
 ```
 
 This script can also be ran with an application like Tautulli to automatically download a trailer each time a new movie is added to Plex. To set this up, open Tautulli and go to Settings > Notification Agents and add a new notification agent. The type should be "script" and you'll want to add the path to the folder the scripts are located in and select download.py as your script in the configuration tab. Also add a name for the description. Next, go to the triggers tab and check the box for "Recently Added" and then go to the conditions tab and add a condition to only fire when "media type is movie". For the arguments tab, go to the "Recently Added" section and add the code below. After that, be sure to save it and you're all set.
 ```
-<movie>--title "{title}" --year "{year}" --file "{file}"</movie>
+<movie>nopythonpath python3 --title "{title}" --year "{year}" --file "{file}"</movie>
 ```
 
 ### Download Trailers For All Movies In A Directory
 
 To download trailers for an entire library that already exists, use the command below. You will need to supply the directory that all of your movie folders are in. The script will iterate through all of your movie folders in the directory and it will automatically pull the title and year from the folder name. Trailers will be downloaded into the folder for each movie.
 ```
-python3 /path/to/download_all.py --directory "/path/to/movies"
+python3 download_all.py --directory "/path/to/movies"
 ```
 
 This script expects your movies to be in a very specific structure. If your movies do not match the format below, you **will not** be able to use this script.


### PR DESCRIPTION
After much playing with the code I've finally got it working 100% on Linux, Obviously this needs testing on Windows and other OS environments but I think it should work.

**Setup**
Go to radarrs settings page and click on the **CONNECT** setting option

> ![Annotation 2019-06-24 200112](https://user-images.githubusercontent.com/8677023/60045202-20cf8600-96bc-11e9-80a4-867fb2340589.png)


click the **+** icon to add a new notification and select **CUSTOM SCRIPT**

> ![Annotation 2019-06-24 200230](https://user-images.githubusercontent.com/8677023/60045282-60966d80-96bc-11e9-94a4-e9d1b9ec804c.png)

Name your script whatever you like although obviously Trailer Downloader is appropriate, toggle the **ON GRAB** to no as we need the trailer to follow the movie to its final destination. Also at this stage the movie name etc wont be as concise for the script to work.

Enter the path to Python in the **PATH** box (note this will be different on each OS, example being from _Ubuntu 18.04_).
In the **ARGUMENTS** box enter the absolute path to the radarr.py script contained within the Trailer Downloader directory.

> ![Annotation 2019-06-24 200414](https://user-images.githubusercontent.com/8677023/60045353-976c8380-96bc-11e9-8650-de78841e841d.png)

Ive tested this code over the last few days and every file has been successful. I hope after further testing this can be incorporated into the main branch. Please bare in mind  #I am no coder.

[radarr.zip](https://github.com/airship-david/Trailer-Downloader/files/3322214/radarr.zip)