### PR TITLE
Fix YouTube search and Radarr downloads

### DIFF
--- a/download.py
+++ b/download.py
@@ -332,7 +332,7 @@ def main():
                                     if file:
                                         downloaded = True
                                         break
-
+                    if downloaded:
                         break
 
             if downloaded:

--- a/download_radarr.py
+++ b/download_radarr.py
@@ -35,13 +35,15 @@ def getArguments():
 def main():
     # Arguments
     arguments = getArguments()
-    if '/' in arguments['file']:
-        arguments['file'].rstrip("\\/")+='/'
-    else:
-        arguments['file'].rstrip("\\/")+="\\"
-
+    
     # Make sure a file path was passed from radarr
     if arguments['file'] is not None:
+        # In case some Radarr versions end this variable with a slash, remove it
+        arguments['file']=arguments['file'].rstrip("\\/")
+        if '/' in arguments['file']:
+            arguments['file']+='/'
+        else:
+            arguments['file']+="\\"
 
         # Make sure file path exists
         if not os.path.isdir(arguments['file']):

--- a/download_radarr.py
+++ b/download_radarr.py
@@ -35,12 +35,16 @@ def getArguments():
 def main():
     # Arguments
     arguments = getArguments()
+    if '/' in arguments['file']:
+        arguments['file'].rstrip("\\/")+='/'
+    else:
+        arguments['file'].rstrip("\\/")+="\\"
 
     # Make sure a file path was passed from radarr
     if arguments['file'] is not None:
 
         # Make sure file path exists
-        if not os.path.isfile(arguments['file']):
+        if not os.path.isdir(arguments['file']):
             print('\033[91mERROR:\033[0m The provided file path does not exist. Check your arguments.')
             sys.exit()
 


### PR DESCRIPTION
- YouTube search wasn't iterating through results properly

- Radarr file environment variable needed a closing slash to work properly; tested on Linux with forward slash and hopefully works with backslashes on Windows as well
- path was being checked with os.path.isfile() when it needs os.path.isdir()