### PR TITLE
v1.13

### DIFF
--- a/download.py
+++ b/download.py
@@ -52,7 +52,7 @@ except:
 # Arguments
 def getArguments():
     name = 'Trailer-Downloader'
-    version = '1.12'
+    version = '1.13'
     parser = ArgumentParser(description='{}: download a movie trailer from Apple or YouTube with help from TMDB'.format(name))
     parser.add_argument('-v', '--version', action='version', version='{} {}'.format(name, version), help='show the version number and exit')
     parser.add_argument('-d', '--directory', dest='directory', help='full path of directory to copy downloaded trailer', metavar='DIRECTORY')

--- a/download_all.py
+++ b/download_all.py
@@ -23,7 +23,7 @@ except:
 # Arguments
 def getArguments():
     name = 'Trailer-Downloader Library Integration'
-    version = '1.12'
+    version = '1.13'
     parser = ArgumentParser(description='{}: download a movie trailer from Apple or YouTube with help from TMDB for all folders in a directory'.format(name))
     parser.add_argument('-v', '--version', action='version', version='{} {}'.format(name, version), help='show the version number and exit')
     parser.add_argument('-d', '--directory', dest='directory', help='directory used to find movie titles and years', metavar='DIRECTORY')

--- a/download_radarr.py
+++ b/download_radarr.py
@@ -23,7 +23,7 @@ except:
 # Arguments
 def getArguments():
     name = 'Trailer-Downloader Radarr Integration'
-    version = '1.12'
+    version = '1.13'
     parser = ArgumentParser(description='{}: download a movie trailer from Apple or YouTube with help from TMDB'.format(name))
     parser.add_argument('-v', '--version', action='version', version='{} {}'.format(name, version), help='show the version number and exit')
     args = parser.parse_args()
@@ -35,7 +35,7 @@ def getArguments():
 def main():
     # Arguments
     arguments = getArguments()
-    
+
     # Make sure a file path was passed from radarr
     if arguments['file'] is not None:
         # In case some Radarr versions end this variable with a slash, remove it

--- a/download_tautulli.py
+++ b/download_tautulli.py
@@ -23,7 +23,7 @@ except:
 # Arguments
 def getArguments():
     name = 'Trailer-Downloader Tautulli Integration'
-    version = '1.12'
+    version = '1.13'
     parser = ArgumentParser(description='{}: download a movie trailer from Apple or YouTube with help from TMDB'.format(name))
     parser.add_argument('-v', '--version', action='version', version='{} {}'.format(name, version), help='show the version number and exit')
     parser.add_argument('-f', '--file', dest='file', help='full path of movie file', metavar='FILE')


### PR DESCRIPTION
1. YouTube search wasn't iterating through results properly

2. Radarr file environment variable needed a closing slash to work properly; tested on Linux with forward slash and hopefully works with backslashes on Windows as well

3. path was being checked with os.path.isfile() when it needs os.path.isdir()